### PR TITLE
Fix signup: correct Supabase env var and add signup link to signin page

### DIFF
--- a/api/create-trial-account.js
+++ b/api/create-trial-account.js
@@ -1,6 +1,9 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.REACT_APP_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
 
 // Default questions based on venue type (mirrors admin create-account flow)
 const DEFAULT_QUESTIONS = {

--- a/src/pages/auth/SignIn.js
+++ b/src/pages/auth/SignIn.js
@@ -228,6 +228,14 @@ const SignInPage = () => {
               )}
             </button>
           </form>
+
+          {/* Sign up link */}
+          <div className="mt-6 text-center">
+            <span className="text-gray-500 text-sm">Don't have an account? </span>
+            <Link to="/signup" className="text-sm font-medium text-[#4E74FF] hover:text-[#2F5CFF]">
+              Start free trial
+            </Link>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
- Use REACT_APP_SUPABASE_URL (matching all other API files) instead of SUPABASE_URL which doesn't exist on Vercel, causing 500 error
- Add "Don't have an account? Start free trial" link to signin page