### PR TITLE
Fix RLS error: use admin.createUser instead of signUp

### DIFF
--- a/api/create-trial-account.js
+++ b/api/create-trial-account.js
@@ -86,10 +86,11 @@ export default async function handler(req, res) {
       return res.status(400).json({ error: 'An account with this email already exists' });
     }
 
-    // 2. Create auth user
-    const { data: authData, error: authError } = await supabase.auth.signUp({
+    // 2. Create auth user (use admin API to avoid changing client auth context)
+    const { data: authData, error: authError } = await supabase.auth.admin.createUser({
       email: email.toLowerCase(),
-      password
+      password,
+      email_confirm: true
     });
     if (authError) throw new Error(authError.message);
 


### PR DESCRIPTION
signUp() on a service-role client changes the auth context to the new user, causing subsequent inserts to fail RLS. admin.createUser() keeps the service role context intact.