### PR TITLE
Disable login and signup buttons on marketing site

### DIFF
--- a/src/components/home/FinalCTA.jsx
+++ b/src/components/home/FinalCTA.jsx
@@ -20,13 +20,10 @@ const FinalCTA = () => {
 
           {/* Buttons */}
           <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
-            <a
-              href={getDashboardUrl('/signup')}
-              className="inline-flex items-center justify-center px-8 py-4 text-lg font-semibold text-white bg-[#4E74FF] rounded-lg hover:bg-[#2F5CFF] transition-all duration-200 shadow-lg hover:shadow-xl"
-            >
+            <span className="inline-flex items-center justify-center px-8 py-4 text-lg font-semibold text-white bg-slate-600 rounded-lg cursor-default">
               Start Free Trial
               <ArrowRight className="ml-2 w-5 h-5" />
-            </a>
+            </span>
             <Link
               to="/pricing"
               className="inline-flex items-center justify-center px-8 py-4 text-lg font-semibold text-white bg-transparent border-2 border-white rounded-lg hover:bg-white/10 transition-all duration-200"

--- a/src/components/home/Hero.jsx
+++ b/src/components/home/Hero.jsx
@@ -178,13 +178,10 @@ const Hero = () => {
                 See Pricing
                 <ArrowRight className="ml-2 w-5 h-5" />
               </Link>
-              <a
-                href={getDashboardUrl('/signup')}
-                className="inline-flex items-center justify-center px-8 py-4 text-lg font-semibold text-white bg-white/10 border border-white/20 rounded-xl hover:bg-white/20 transition-all duration-200"
-              >
+              <span className="inline-flex items-center justify-center px-8 py-4 text-lg font-semibold text-white/50 bg-white/5 border border-white/10 rounded-xl cursor-default">
                 Start Free Trial
                 <ArrowRight className="ml-2 w-5 h-5" />
-              </a>
+              </span>
             </div>
 
             {/* Microcopy */}

--- a/src/components/home/HowItWorks.jsx
+++ b/src/components/home/HowItWorks.jsx
@@ -331,13 +331,10 @@ const HowItWorks = () => {
 
         {/* CTA Link */}
         <div className="text-center">
-          <a
-            href={getDashboardUrl('/signup')}
-            className="inline-flex items-center text-[#4E74FF] font-semibold hover:text-[#2F5CFF] transition-colors"
-          >
+          <span className="inline-flex items-center text-gray-400 font-semibold cursor-default">
             Start Free Trial
             <ArrowRight className="ml-2 w-5 h-5" />
-          </a>
+          </span>
         </div>
       </div>
 

--- a/src/components/home/Pricing.jsx
+++ b/src/components/home/Pricing.jsx
@@ -77,13 +77,10 @@ const Pricing = () => {
                 </div>
               </div>
 
-              <a
-                href={getDashboardUrl('/signup')}
-                className="mt-8 inline-flex w-full items-center justify-center gap-2 rounded-xl bg-[#4E74FF] hover:bg-[#3D5BD9] px-8 py-4 text-lg font-semibold text-white shadow-lg shadow-[#4E74FF]/40 transition-all duration-200 hover:scale-[1.01] hover:shadow-xl"
-              >
+              <span className="mt-8 inline-flex w-full items-center justify-center gap-2 rounded-xl bg-gray-400 px-8 py-4 text-lg font-semibold text-white cursor-default">
                 Start Free Trial
                 <ArrowRight className="w-5 h-5" />
-              </a>
+              </span>
             </div>
           </div>
         </div>

--- a/src/components/marketing/layout/Navbar.js
+++ b/src/components/marketing/layout/Navbar.js
@@ -272,18 +272,12 @@ const Navbar = ({ overlay = false }) => {
 
           {/* Right: Auth */}
           <div className="hidden lg:flex lg:items-center lg:space-x-4">
-            <Link
-              to={getDashboardUrl('/signin')}
-              className="text-sm font-medium text-gray-700 hover:text-[#4E74FF] transition-colors duration-150"
-            >
+            <span className="text-sm font-medium text-gray-400 cursor-default">
               Log in
-            </Link>
-            <a
-              href={getDashboardUrl('/signup')}
-              className="inline-flex items-center justify-center px-4 py-2 text-sm font-semibold text-white bg-[#4E74FF] rounded-lg hover:bg-[#2F5CFF] transition-all duration-200"
-            >
+            </span>
+            <span className="inline-flex items-center justify-center px-4 py-2 text-sm font-semibold text-white bg-gray-400 rounded-lg cursor-default">
               Start Free Trial
-            </a>
+            </span>
           </div>
 
           {/* Mobile toggle */}
@@ -391,20 +385,12 @@ const Navbar = ({ overlay = false }) => {
           {/* Sticky bottom CTA bar */}
           <div className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 px-4 py-4 shadow-[0_-4px_20px_rgba(0,0,0,0.1)]">
             <div className="flex gap-3">
-              <Link
-                to={getDashboardUrl('/signin')}
-                onClick={() => setIsMobileMenuOpen(false)}
-                className="flex-1 text-center border border-gray-300 text-gray-700 px-4 py-3 rounded-lg text-sm font-medium hover:bg-gray-50 transition-colors"
-              >
+              <span className="flex-1 text-center border border-gray-200 text-gray-400 px-4 py-3 rounded-lg text-sm font-medium cursor-default">
                 Log in
-              </Link>
-              <a
-                href={getDashboardUrl('/signup')}
-                onClick={() => setIsMobileMenuOpen(false)}
-                className="flex-1 text-center bg-[#4E74FF] text-white px-4 py-3 rounded-lg text-sm font-semibold hover:bg-[#2F5CFF] transition-colors"
-              >
+              </span>
+              <span className="flex-1 text-center bg-gray-400 text-white px-4 py-3 rounded-lg text-sm font-semibold cursor-default">
                 Start Free Trial
-              </a>
+              </span>
             </div>
           </div>
         </div>

--- a/src/pages/marketing/Pricing.js
+++ b/src/pages/marketing/Pricing.js
@@ -109,13 +109,10 @@ const PricingCard = () => (
               </div>
             </div>
 
-            <a
-              href={getDashboardUrl('/signup')}
-              className="mt-8 inline-flex w-full items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-indigo-600 via-indigo-500 to-sky-500 px-8 py-4 text-lg font-semibold text-white shadow-lg shadow-indigo-300/40 transition-transform duration-200 hover:scale-[1.01] hover:shadow-xl"
-            >
+            <span className="mt-8 inline-flex w-full items-center justify-center gap-2 rounded-xl bg-gray-400 px-8 py-4 text-lg font-semibold text-white cursor-default">
               Start Free Trial
               <ArrowRight className="w-5 h-5" />
-            </a>
+            </span>
           </div>
         </div>
       </div>
@@ -257,13 +254,10 @@ const FinalCTA = () => (
         Start your 14-day free trial. No credit card required, no hidden fees.
       </p>
       <div className="flex flex-col sm:flex-row gap-4 justify-center">
-        <a
-          href={getDashboardUrl('/signup')}
-          className="inline-flex items-center justify-center px-8 py-4 text-lg font-semibold text-white bg-[#4E74FF] rounded-lg hover:bg-[#2F5CFF] transition-all duration-200 shadow-lg hover:shadow-xl group"
-        >
+        <span className="inline-flex items-center justify-center px-8 py-4 text-lg font-semibold text-white bg-slate-600 rounded-lg cursor-default">
           Start Free Trial
-          <ArrowRight className="ml-2 w-5 h-5 group-hover:translate-x-1 transition-transform" />
-        </a>
+          <ArrowRight className="ml-2 w-5 h-5" />
+        </span>
         <Link
           to="/pricing"
           className="inline-flex items-center justify-center px-8 py-4 text-lg font-semibold text-white border-2 border-white/30 rounded-lg hover:bg-white/10 transition-all duration-200"


### PR DESCRIPTION
## Summary

- Converts all login/signup buttons and links across the marketing site into inert `<span>` elements
- Buttons are visually grayed out (`bg-gray-400`, `cursor-default`) and no longer navigate anywhere
- Affects: Navbar (desktop + mobile), Hero, FinalCTA, Pricing component, HowItWorks, Pricing page

## Files changed

- `src/components/marketing/layout/Navbar.js`
- `src/components/home/Hero.jsx`
- `src/components/home/FinalCTA.jsx`
- `src/components/home/Pricing.jsx`
- `src/components/home/HowItWorks.jsx`
- `src/pages/marketing/Pricing.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)